### PR TITLE
Add whole node_modules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 .docusaurus
 node_modules/.cache
+node_modules/


### PR DESCRIPTION
The whole `node_modules` folder not be in source control it since `npm install` will already download the right files for your system.